### PR TITLE
Corrected exception handling to account for skipped images.

### DIFF
--- a/PCV/tools/imtools.py
+++ b/PCV/tools/imtools.py
@@ -17,13 +17,17 @@ def compute_average(imlist):
     
     # open first image and make into array of type float
     averageim = array(Image.open(imlist[0]), 'f') 
+
+    skipped = 0
     
     for imname in imlist[1:]:
         try: 
             averageim += array(Image.open(imname))
         except:
             print imname + "...skipped"  
-    averageim /= len(imlist) 
+            skipped += 1
+
+    averageim /= (len(imlist) - skipped)
     
     # return average as uint8
     return array(averageim, 'uint8')

--- a/pcv_book/imtools.py
+++ b/pcv_book/imtools.py
@@ -17,13 +17,17 @@ def compute_average(imlist):
     
     # open first image and make into array of type float
     averageim = array(Image.open(imlist[0]), 'f') 
+
+    skipped = 0
     
     for imname in imlist[1:]:
         try: 
             averageim += array(Image.open(imname))
         except:
             print imname + "...skipped"  
-    averageim /= len(imlist) 
+            skipped += 1
+
+    averageim /= (len(imlist) - skipped)
     
     # return average as uint8
     return array(averageim, 'uint8')


### PR DESCRIPTION
If the compute_average function skipped one or more images, the resulting average image would still have been divided by the length of the list of image names (and therefore the resulting average image would be darker than expected.)  I've added a skip counter to allow for proper handling of skipped images.
