### PR TITLE
Fix ROF code.

### DIFF
--- a/PCV/tools/rof.py
+++ b/PCV/tools/rof.py
@@ -15,8 +15,8 @@ def denoise(im,U_init,tolerance=0.1,tau=0.125,tv_weight=100):
 
     # initialize
     U = U_init
-    Px = im #x-component to the dual field
-    Py = im #y-component of the dual field
+    Px = zeros((m, n)) #x-component to the dual field
+    Py = zeros((m, n)) #y-component of the dual field
     error = 1 
     
     while (error > tolerance):

--- a/pcv_book/rof.py
+++ b/pcv_book/rof.py
@@ -15,8 +15,8 @@ def denoise(im,U_init,tolerance=0.1,tau=0.125,tv_weight=100):
 
     # initialize
     U = U_init
-    Px = im #x-component to the dual field
-    Py = im #y-component of the dual field
+    Px = zeros((m, n)) #x-component to the dual field
+    Py = zeros((m, n)) #y-component of the dual field
     error = 1 
     
     while (error > tolerance):


### PR DESCRIPTION
The Chambolle paper this is based on --
http://www.cmap.polytechnique.fr/preprint/repository/578.pdf --
initializes Xi_0 with 0, not with g (see page 13 at the bottom).

Consider this code:

```
im = misc.lena()
U, T = rof.denoise(im, im, tv_weight=30)
imshow(U)
```

Before this change, this produced the output
http://i.imgur.com/u68Vakj.jpg . With this change, it produces
http://i.imgur.com/3eHli7J.jpg which looks more correct.
