### PR TITLE
docs: fix simple typo, funtion -> function

### DIFF
--- a/PCV/tools/imtools.py
+++ b/PCV/tools/imtools.py
@@ -64,7 +64,7 @@ def histeq(im,nbr_bins=256):
     
 def plot_2D_boundary(plot_range,points,decisionfcn,labels,values=[0]):
     """    Plot_range is (xmin,xmax,ymin,ymax), points is a list
-        of class points, decisionfcn is a funtion to evaluate, 
+        of class points, decisionfcn is a function to evaluate, 
         labels is a list of labels that decisionfcn returns for each class, 
         values is a list of decision contours to show. """
         

--- a/pcv_book/imtools.py
+++ b/pcv_book/imtools.py
@@ -64,7 +64,7 @@ def histeq(im,nbr_bins=256):
     
 def plot_2D_boundary(plot_range,points,decisionfcn,labels,values=[0]):
     """    Plot_range is (xmin,xmax,ymin,ymax), points is a list
-        of class points, decisionfcn is a funtion to evaluate, 
+        of class points, decisionfcn is a function to evaluate, 
         labels is a list of labels that decisionfcn returns for each class, 
         values is a list of decision contours to show. """
         


### PR DESCRIPTION
There is a small typo in PCV/tools/imtools.py, pcv_book/imtools.py.

Should read `function` rather than `funtion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md